### PR TITLE
Add instructions for online editing as per Paul's suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,43 @@ Of course, a Git repo can contain almost anything. Code, images, more sophistica
 A lot of documents and information will still likely live in things like Google Drive/Docs. That's fine. The Markdown documents in the handbook serve as a guide and set of links to those resources (just as a Wiki would contain links to such assets). Over time it's probably a good thing if more documents may move into the actual Git repository itself, but it's not essential that this happen.
 
 ### How can I use it?
-You need some familiarity with the basics of:
+To do more than the absolute basics, you should get some familiarity with the basics of:
 - Git: cloning, committing, forking/branching, creating pull requests, and merging.
 - Markdown: Creating text with styling, links, and embedded images.
 
 [Here are some learning resources for these tools](Resources/learning_resources.md).
 
-#### Getting started by editing a page
+### Quickstart 
+GitHub allows editing of text files directly from your browser. Furthermore, GitHub "speaks Markdown," so you can preview your edits to the most common kind of documentation file directly. However, we don't want people editing the "main branch" directly the way you would with a Wiki; the advantage of Git (and version control in general) is that anyone can copy, modify, and use everything in the repo, and anyone can _propose_ changes, but it's impossible for non-members to unilaterally change the ```main``` copy (and highly discouraged for members to do so; best practice is to always propose changes via a pull request and ask another member to merge them; this ensures more eyes on all changes and greatly reduces mistakes). 
+
+If you are a member of the organization, follow the "Quickstart for members" instructions. If not, follow the "Quickstart for non-members" instructions.
+
+#### Quickstart for members: edit a page online, then make a branch and pull request!
+This is how to propose changes if you are a member of the organization, and therefore can directly edit the repository (though, again, best practice is to never unilaterally modify the ```main``` branch; always propose changes via [this workflow](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/proposing-changes-to-your-work-with-pull-requests) using [branches](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-branches) and [pull requests](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests)). 
+- Click around the links available from this very page. It looks and works like a wiki to a reader, it's the editing process that is different.
+- Choose a file to edit (even the one you are reading now)! Click the pencil icon at the upper right. You'll find yourself in an editing page.
+- Make your changes, and preview them with the Preview Changes tab at the upper left. The [Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) is a great reference for the syntax (which is quite similar to [Wiki syntax](https://en.wikipedia.org/wiki/Wiki#Editing), but GitHub—and this handbook—use Markdown, _not_ Wikitext).
+- Scroll down to the bottom of the page, and select the checkbox that says "Create a new branch for this commit and start a pull request." Please _do not_ commit directly to the ```main``` branch. Make a name for your branch (something short and without spaces, for example "online-editing-instructions". 
+- Click the Propose Changes button. This will create a [Pull Request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests). 
+- In the pull request window, add a description of what you've done. For small changes, a short sentence is sufficient. For large, potentially controversial changes, you should explain your reasoning thoroughly! It's also a good idea to select people to review changes, and assign someone to merge them (both reviewers and assignees can be selected on the right). Someone will (hopefully) "merge" your proposed changes when they see how helpful you have been!
+
+#### Quickstart for non-members: fork the repo, edit a page online, and make a pull request!
+GitHub allows editing of text files directly from your browser. Furthermore, GitHub "speaks Markdown," so you can preview your edits to the most common kind of documentation file directly. However, we don't want people editing the "main branch" directly the way you would with a Wiki; the advantage of Git (and version control in general) is that anyone can copy, modify, and use everything in the repo, and anyone can _propose_ changes, but it's impossible for non-members to unilaterally change the ```main``` copy (and highly discouraged for members to do so; best practice is to always propose changes via a pull request and ask another member to merge them; this ensures more eyes on all changes and greatly reduces mistakes). 
+
+This is how to propose changes if you are _not_ a member of the organization, and therefore cannot directly modify the handbook (though it's not much different, or more difficult, than the way members propose changes). 
+- Click around the links available from this very page. It looks and works like a wiki to a reader, it's the editing process that is different.
+- Fork this repo. Click the Fork button, and it'll create a copy of this repository in _your_ GitHub account ([instructions here](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo#fork-an-example-repository)). 
+- Now you are in your own fork (copy) of the repo. Choose any file you like (even this one that you are reading right now) and click the pencil icon at the upper right. You'll find yourself in an editing page.
+- Make your changes, and preview them with the Preview Changes tab at the upper left. The [Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) is a great reference for the syntax (which is quite similar to [Wiki syntax](https://en.wikipedia.org/wiki/Wiki#Editing), but GitHub—and this handbook—use Markdown, _not_ Wikitext).
+- Hit the Commit Changes button at the bottom of the page. This will modify _your_ ```main``` branch, but not the original you forked from (yet).
+- Create a Pull Request __TODO: add instructions__. Someone will (hopefully) "merge" your proposed changes when they see how helpful you have been!
+
+#### Getting started by editing a page on your local computer
 - Click around the links available from this very page! Again, it looks and works like a Wiki; it's the editing that is different.
 - Get an account on GitHub (free to sign up).
-- Clone this repository. Open it up in your file manager on your computer; you'll note that the folder structure mirrors the link structure (you can figure out where any document in the repo is by examining the URL of the link to it).
+- Fork this repo. Click the Fork button, and it'll create a copy of this repository in _your_ GitHub account ([instructions here](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo#fork-an-example-repository)). 
+- Clone the repository to your local computer ([instructions here](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository)). Open it up in your file manager on your computer; you'll note that the folder structure mirrors the link structure (you can figure out where any document in the repo is by examining the URL of the link to it).
 - Pick a document you want to modify.
-- Fork the repo.
 - Make your changes to the page (Markdown document) you want to improve.
 - Submit a pull request with explanation of your changes. Once it's accepted, congratulations: you are now a co-creator of the handbook.
   - Later you may be given commit privileges to the handbook, meaning you can be one of the people authorized to commit to the main branch of repo, and therefore accept (merge) pull requests (note that it's often considered a best practice to make a pull request and get someone else to merge it to main, even if you are technically able to directly commit changes to main unilaterally).


### PR DESCRIPTION
On our last call discussing the handbook, Paul mentioned GitHub's features for directly editing Markdown in a browser. This is a great idea, because it's probably the shortest path for someone accustomed to editing Wiki documents to jump to Git/Markdown. I've added instructions for this (and I actually made the changes from my browser, to test the same process I'm documenting—it felt very recursive). 

@kateregga1 we should probably add these changes to the MapUganda repo as well.